### PR TITLE
Don't validate CA certificate of conservancy record

### DIFF
--- a/app/scripts/controllers/verify.coffee
+++ b/app/scripts/controllers/verify.coffee
@@ -42,13 +42,13 @@ angular.module 'xmlFiestaUiApp'
       if $scope.doc.recordPresent && $scope.record instanceof XMLFiesta.ConservancyRecord
         $scope.record.valid = $scope.record.valid()
         $scope.record.validTS = $scope.record.equalTimestamps()
-        $scope.record.validCA = false
+        $scope.record.validCA = true
         $scope.record.validArchive = $scope.record.validArchiveHash()
-        angular.forEach $scope.nom151Ca, (el) ->
-          # dont keep verifying if its already verified
-          if !$scope.record.validCA
-            $scope.record.validCA = $scope.record.isCa(el.content)
-            return
+        # angular.forEach $scope.nom151Ca, (el) ->
+        #   # dont keep verifying if its already verified
+        #   if !$scope.record.validCA
+        #     $scope.record.validCA = $scope.record.isCa(el.content)
+        #     return
 
         $scope.record.tsTranslation =
           recordTS: $filter('date')($scope.record.recordTimestamp(), 'medium', 'UTC')


### PR DESCRIPTION
We don't have the rootCA for the issuer of the conservancy record and the provider can't get it. We are disabling this feature until we get the rootCA of Secretaría de Economía.

Root Certificates of the FIELs are still being validated.